### PR TITLE
Make paying methods responsive

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -46,6 +46,21 @@ body {
   font-size: 1.92rem;
 }
 
+.methods-wrapper{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.pay-method{
+  margin: 2em;
+  padding: 1em;
+  text-align: center;
+  box-shadow: .2em .2em 1em .3em rgb(177, 172, 172);
+}
+
+
 .fa-circle-border {
       display: inline-block;
       border-radius: 60px;

--- a/donate.html
+++ b/donate.html
@@ -146,15 +146,15 @@
 
 
         <div class="card">
-            <div class="step-element d-flex">
+            <div class="step-element">
                 <div class="step-wrapper pr-3">
                     <div class="step d-flex align-items-center justify-content-center display-7">
-                        &nbsp; Select your preferred method.
+                        <h2>Select your preferred method.</h2>
                     </div>
                 </div>
-                <div class="step-wrapper pr-3">
+                <div class="step-wrapper pr-3 methods-wrapper">
                     <!-- Footer Donation Bitcoin -->
-                    <div class="step-wrapper pr-3">
+                    <div class="step-wrapper pr-3 pay-method">
                         <h4 class="mbr-step-title pb-3 mbr-fonts-style display-5">Bitcoin</h4>
                         <p class="mbr-step-text mbr-fonts-style display-7">
                             <img class="qrcode-image"
@@ -166,7 +166,7 @@
                             <span style="font-size: 9pt;">1LQuHz5AHZ1GVsjqMS63oH4GTPwpioF3J6</span>
                         </p>
                     </div>
-                    <div class="step-wrapper pr-3">
+                    <div class="step-wrapper pr-3 pay-method">
                         <h4 class="mbr-step-title pb-3 mbr-fonts-style display-5">Ethereum</h4>
                         <p class="mbr-step-text mbr-fonts-style display-7">
                             <img class="qrcode-image"
@@ -178,7 +178,7 @@
                             <span style="font-size: 9pt;">0x28599c4E4a81A4B85755265B70E8E8cfe016Df24</span>
                         </p>
                     </div>
-                    <div class="step-wrapper pr-3">
+                    <div class="step-wrapper pr-3 pay-method">
                         <h4 class="mbr-step-title pb-3 mbr-fonts-style display-5">PayPal</h4>
                         <!-- https://developer.paypal.com/docs/paypal-payments-standard/integration-guide/html-example-donate/ -->
 


### PR DESCRIPTION
All three QR-Codes are rearranging themselves based on screen width. 
That way they stay always in the center and keep their look.